### PR TITLE
Revert charging limit standard setting

### DIFF
--- a/Source/sys-clk-OC/common/include/sysclk/config.h
+++ b/Source/sys-clk-OC/common/include/sysclk/config.h
@@ -13,7 +13,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-const uint32_t CHARGING_CURRENT_MA_LIMIT = 3000;
+const uint32_t CHARGING_CURRENT_MA_LIMIT = 2000;
 
 typedef enum {
     SysClkConfigValue_PollingIntervalMs = 0,


### PR DESCRIPTION
The default value shouldn't be high since it has known side-effects. If a user wants to tweak it, they're free to do it from the user interface.